### PR TITLE
Deal with spaces in directory names

### DIFF
--- a/odp2pdf.sh
+++ b/odp2pdf.sh
@@ -120,7 +120,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "X""$outfile" = "X" ]; then
-    outfile=$(dirname $(readlink -f "$infile"))"/"$(basename -s .odp "$infile")".pdf"
+    outfile=$(dirname "$(readlink -f "$infile")")"/"$(basename -s .odp "$infile")".pdf"
 else
     outfile=$(readlink -f "$outfile")
 fi


### PR DESCRIPTION
This fixes #1

For example `/home/me/my work/test.odp` would fail when trying to move the file.

This works in Ubuntu 14.04 - and is _likely_ to work on most Linux based systems.  But that's not guaranteed.  There's a good explanation at http://stackoverflow.com/questions/8658868/shell-script-and-spaces-in-path
